### PR TITLE
Add collapsible sidebar and cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -5,6 +5,8 @@
 
 /* Sidebar en "mode brique" sombre */
 #sidebar {
+    transition: width 0.3s;
+
     width: 250px; /* largeur fixe pour la barre */
     min-height: 100vh; /* hauteur de toute la fenêtre */
     background-color: #2c2c2c; /* fond sombre */
@@ -27,3 +29,14 @@ main {
     background-color: #343a40; /* fond sombre pour le contenu */
     min-height: 100vh;
 }
+#sidebar.collapsed {
+    width: 80px;
+}
+#sidebar.collapsed h2,
+#sidebar.collapsed .nav-link span {
+    display: none;
+}
+#sidebar.collapsed .nav-link {
+    text-align: center;
+}
+

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <!-- Feuille de style personnalisée -->
     <link href="css/styles.css" rel="stylesheet">
     <title>Backoffice Demo</title>
@@ -13,17 +14,18 @@
 <body>
     <!-- Barre latérale gauche -->
     <div class="d-flex">
+        <button class="btn btn-secondary m-2" id="menu-toggle"><i class="bi bi-list"></i></button>
         <nav id="sidebar" class="bg-dark text-white p-3">
             <h2 class="text-center">Menu</h2>
             <ul class="nav flex-column">
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="#">Dashboard</a>
+                    <a class="nav-link text-white" href="#"><i class="bi bi-speedometer2 me-2"></i><span>Dashboard</span></a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="#">Rapports</a>
+                    <a class="nav-link text-white" href="#"><i class="bi bi-file-bar-graph me-2"></i><span>Rapports</span></a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-white" href="#">Paramètres</a>
+                    <a class="nav-link text-white" href="#"><i class="bi bi-gear me-2"></i><span>Paramètres</span></a>
                 </li>
             </ul>
         </nav>
@@ -31,6 +33,40 @@
         <main class="flex-grow-1 p-4">
             <h1>Bienvenue dans le backoffice</h1>
             <p>Ceci est un exemple de template backoffice utilisant Bootstrap.</p>
+            <div class="container mt-4">
+                <div class="row row-cols-1 row-cols-md-3 g-4">
+                    <div class="col">
+                        <div class="card h-100 text-center">
+                            <div class="card-body">
+                                <i class="bi bi-box-seam fs-1"></i>
+                                <h5 class="card-title mt-2">Titre 1</h5>
+                                <p class="card-text">Description de la carte 1.</p>
+                                <a href="#" class="btn btn-primary">Action</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="card h-100 text-center">
+                            <div class="card-body">
+                                <i class="bi bi-heart fs-1"></i>
+                                <h5 class="card-title mt-2">Titre 2</h5>
+                                <p class="card-text">Description de la carte 2.</p>
+                                <a href="#" class="btn btn-primary">Action</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="card h-100 text-center">
+                            <div class="card-body">
+                                <i class="bi bi-gear fs-1"></i>
+                                <h5 class="card-title mt-2">Titre 3</h5>
+                                <p class="card-text">Description de la carte 3.</p>
+                                <a href="#" class="btn btn-primary">Action</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </main>
     </div>
 

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -2,3 +2,11 @@
 // Pour l'instant, ce fichier est vide mais prêt à recevoir du code.
 
 console.log('Backoffice chargé');
+// Gestion du bouton hamburger pour réduire la sidebar
+const toggleBtn = document.getElementById('menu-toggle');
+const sidebar = document.getElementById('sidebar');
+if (toggleBtn && sidebar) {
+    toggleBtn.addEventListener('click', () => {
+        sidebar.classList.toggle('collapsed');
+    });
+}


### PR DESCRIPTION
## Summary
- add hamburger button to collapse sidebar
- include icons in sidebar links
- show cards in a three-column grid on the home page
- implement collapsed sidebar styles
- handle sidebar toggle in JS

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6853e48d8e008329ade4969797327e44